### PR TITLE
Simplify daily motion video URL matching (#2228)

### DIFF
--- a/apps/videos/types/dailymotion.py
+++ b/apps/videos/types/dailymotion.py
@@ -49,13 +49,7 @@ class DailymotionVideoType(VideoType):
 
     @classmethod
     def matches_video_url(cls, url):
-        video_id = cls.get_video_id(url)
-        if video_id:
-            metadata = cls.get_metadata(video_id)
-            stream_flv_mini_url = metadata.get('url', '')
-            return bool(stream_flv_mini_url)
-
-        return False
+        return bool(cls.get_video_id(url))
 
     def set_values(self, video_obj):
         metadata = self.get_metadata(self.video_id)


### PR DESCRIPTION
Made it so DailymotionVideoType.matches_video_url() just checks the
form of the video URL, it doesn't actually try to make an API request.

This seems good in general to avoid requests and it also avoids the
exception in the API code.  The exception might happen in other
places, but I think that could be correct in those situations.