### PR TITLE
Workaround for updating video titles (#2324)

### DIFF
--- a/apps/api/views/subtitles.py
+++ b/apps/api/views/subtitles.py
@@ -683,8 +683,9 @@ class SubtitlesView(generics.CreateAPIView):
         if not workflow.user_can_edit_subtitles(
             self.request.user, self.kwargs['language_code']):
             raise PermissionDenied()
+        version = super(SubtitlesView, self).create(request, *args, **kwargs)
         videos.tasks.video_changed_tasks.delay(video.pk)
-        return super(SubtitlesView, self).create(request, *args, **kwargs)
+        return version
 
 class ActionsSerializer(serializers.Serializer):
     action = serializers.CharField(source='name')


### PR DESCRIPTION
The point of this is to call video_changed_tasks() after the subtitles
are created.  video_changed_tasks() causes the video to be loaded then
saved from the DB, so we want it to happen after other changes happen.