### PR TITLE
Fixed alt text styling (pculture/amara-enterprise#403)

### DIFF
--- a/media/src/css/site/lists.scss
+++ b/media/src/css/site/lists.scss
@@ -32,6 +32,9 @@ ul.activity {
         width: $height * 16 / 9;
         height: $height;
         line-height: $height;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
     }
 }
 


### PR DESCRIPTION
If the image was a broken link, then some browsers display the alt
text.  Added CSS for this to make it only display 1 line of text.