### PR TITLE
Fix for DFXP with an encoding specified (#2367)

### DIFF
--- a/apps/api/views/subtitles.py
+++ b/apps/api/views/subtitles.py
@@ -513,7 +513,7 @@ class SubtitlesField(serializers.CharField):
             raise serializers.ValidationError("Invalid subtitle data")
         try:
             return load_subtitles(
-                self.context['language_code'], value,
+                self.context['language_code'], str(value),
                 self.context['sub_format'])
         except babelsubs.SubtitleParserError:
             raise serializers.ValidationError("Invalid subtitle data")


### PR DESCRIPTION
Enables to import DFXP files with the following in the first line:

<?xml version="1.0" encoding="UTF-8"?>