### PR TITLE
Fix for KeyError in the all languages page

### DIFF
--- a/apps/teams/new_views.py
+++ b/apps/teams/new_views.py
@@ -330,6 +330,7 @@ def all_languages_page(request, team):
          completed_language_counts.get(lc, 0),
         )
         for lc in all_languages
+        if lc != ''
     ]
     languages.sort(key=lambda row: (-row[2], row[1]))
 


### PR DESCRIPTION
This is for pculture/amara-enterprise#431

Display All Languages page for new team correctly when there are no videos/collabs in the team.