### PR TITLE
Fixed text overflow on the sidebars (pculture/amara-enterprise#433)

### DIFF
--- a/media/src/css/site/split-view.scss
+++ b/media/src/css/site/split-view.scss
@@ -26,6 +26,7 @@
 
         > .section {
             margin-bottom: 60px;
+            overflow: hidden;
         }
     }
 


### PR DESCRIPTION
Long chunks of text in video description (such as long URLs) on collab detail page now do not spill over to the right side of the page.