### PR TITLE
Automatic duration settings of most video types

### DIFF
--- a/apps/externalsites/google.py
+++ b/apps/externalsites/google.py
@@ -403,8 +403,11 @@ def get_video_info(video_id):
         return _get_video_info(video_id)
     except APIError, e:
         logger.error("Youtube API Error: %s, falling back", e)
-        p = pafy.new(video_id)
-        return VideoInfo(None, p.title, "", p.length, p.thumb)
+        try:
+            p = pafy.new(video_id)
+            return VideoInfo(None, p.title, "", p.length, p.thumb)
+        except:
+            raise APIError, e
 
 def _get_video_info(video_id):
     response = video_get(None, video_id, ['snippet', 'contentDetails'])

--- a/apps/externalsites/google.py
+++ b/apps/externalsites/google.py
@@ -412,8 +412,9 @@ def get_video_info(video_id):
         })
         return _get_video_info(video_id)
     except APIError, e:
-        logger.error("Youtube API Error: %s", e)
-        raise
+        logger.error("Youtube API Error: %s, falling back", e)
+        p = pafy.new(video_id)
+        return VideoInfo(None, p.title, "", p.length, p.thumb)
 
 def _get_video_info(video_id):
     response = video_get(None, video_id, ['snippet', 'contentDetails'])

--- a/apps/externalsites/google.py
+++ b/apps/externalsites/google.py
@@ -31,7 +31,7 @@ from django.conf import settings
 from django.utils.translation import ugettext as _
 import jwt
 import requests
-import pafy
+import pafy, isodate
 
 from utils.subtitles import load_subtitles
 from utils.text import fmt
@@ -395,16 +395,6 @@ def get_openid_profile(access_token):
         response.json.get('family_name', ''),
     )
 
-def _parse_8601_duration(duration):
-    """Convert a duration in iso 8601 format to seconds as an integer."""
-    match = re.match(r'PT((\d+)M)?(\d+)S', duration)
-    if match is None:
-        return None
-    rv = int(match.group(3))
-    if match.group(2):
-        rv += int(match.group(2)) * 60
-    return rv
-
 def get_video_info(video_id):
     try:
         logger.info("youtube.get_video_info()", extra={
@@ -424,7 +414,7 @@ def _get_video_info(video_id):
         return VideoInfo(snippet['channelId'],
                          snippet['title'],
                          snippet['description'],
-                         _parse_8601_duration(content_details['duration']),
+                         isodate.parse_duration(content_details['duration']).total_seconds(),
                          snippet['thumbnails']['high']['url'])
     except StandardError, e:
         raise APIError("get_video_info: Unexpected content: %s" % e)

--- a/apps/externalsites/tests/test_youtube_api.py
+++ b/apps/externalsites/tests/test_youtube_api.py
@@ -26,6 +26,7 @@ from nose.tools import *
 from utils import test_utils
 from utils.subtitles import load_subtitles
 from externalsites import google
+import isodate
 
 @override_settings(YOUTUBE_API_KEY='test-youtube-api-key')
 class YouTubeTestCase(TestCase):
@@ -229,10 +230,10 @@ class YouTubeTestCase(TestCase):
 
 class TestTimeParsing(TestCase):
     def test_with_minutes(self):
-        self.assertEqual(google._parse_8601_duration('PT10M10S'), 610)
+        self.assertEqual(isodate.parse_duration('PT10M10S').total_seconds(), 610)
 
     def test_without_minutes(self):
-        self.assertEqual(google._parse_8601_duration('PT10S'), 10)
+        self.assertEqual(isodate.parse_duration('PT10S').total_seconds(), 10)
 
     def test_invalid(self):
-        self.assertEqual(google._parse_8601_duration('foo'), None)
+        self.assertRaises(Exception, isodate.parse_duration, 'foo')

--- a/apps/videos/models.py
+++ b/apps/videos/models.py
@@ -569,6 +569,9 @@ class Video(models.Model):
                 for name, value in set_values.items():
                     if name == 'metadata':
                         self.update_metadata(value, commit=False)
+                    elif name == 'duration':
+                        if value and not getattr(obj, name):
+                            setattr(obj, name, value)
                     else:
                         setattr(obj, name, value)
             if not obj.title:

--- a/apps/videos/types/flv.py
+++ b/apps/videos/types/flv.py
@@ -15,8 +15,11 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see 
 # http://www.gnu.org/licenses/agpl-3.0.html.
-
+import subprocess, sys
 from videos.types.base import VideoType
+
+import logging
+logger= logging.getLogger(__name__)
 
 class FLVVideoType(VideoType):
 
@@ -32,3 +35,14 @@ class FLVVideoType(VideoType):
     @classmethod
     def matches_video_url(cls, url):
         return cls.url_extension(url) == 'flv'
+
+    def set_values(self, video):
+        cmd = """avprobe -v error -show_format -show_streams "{}" | grep duration= | sed 's/^.*=//' | head -n1""".format(self.url)
+        try:
+            duration = int(float(subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)))
+            video.duration = duration
+        except subprocess.CalledProcessError as e:
+            logger.error("CalledProcessError error({}) when running command {}".format(e.returncode, cmd))
+        except:
+            logger.error("Unexpected error({}) when running command {}".format(sys.exc_info()[0], cmd))
+

--- a/apps/videos/types/htmlfive.py
+++ b/apps/videos/types/htmlfive.py
@@ -16,7 +16,11 @@
 # along with this program.  If not, see 
 # http://www.gnu.org/licenses/agpl-3.0.html.
 
+import subprocess, sys
 from videos.types.base import VideoType
+
+import logging
+logger= logging.getLogger(__name__)
 
 class HtmlFiveVideoType(VideoType):
     abbreviation = 'H'
@@ -33,3 +37,13 @@ class HtmlFiveVideoType(VideoType):
 
     def get_direct_url(self):
         return self.url
+
+    def set_values(self, video):
+        cmd = """avprobe -v error -show_format -show_streams "{}" | grep duration= | sed 's/^.*=//' | head -n1""".format(self.url)
+        try:
+            duration = int(float(subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)))
+            video.duration = duration
+        except subprocess.CalledProcessError as e:
+            logger.error("CalledProcessError error({}) when running command {}".format(e.returncode, cmd))
+        except:
+            logger.error("Unexpected error({}) when running command {}".format(sys.exc_info()[0], cmd))

--- a/apps/videos/types/htmlfive.py
+++ b/apps/videos/types/htmlfive.py
@@ -39,7 +39,7 @@ class HtmlFiveVideoType(VideoType):
         return self.url
 
     def set_values(self, video):
-        cmd = """avprobe -v error -show_format -show_streams "{}" | grep duration= | sed 's/^.*=//' | head -n1""".format(self.url)
+        cmd = """avprobe -v error -show_format -show_streams "{}" 2>&1 | grep duration= | sed 's/^.*=//' | sort -n | head -n1""".format(self.url)
         try:
             duration = int(float(subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)))
             video.duration = duration

--- a/apps/videos/types/mp3.py
+++ b/apps/videos/types/mp3.py
@@ -16,7 +16,11 @@
 # along with this program.  If not, see
 # http://www.gnu.org/licenses/agpl-3.0.html.
 
+import subprocess, sys
 from videos.types.base import VideoType
+
+import logging
+logger= logging.getLogger(__name__)
 
 class Mp3VideoType(VideoType):
 
@@ -32,3 +36,13 @@ class Mp3VideoType(VideoType):
     @classmethod
     def matches_video_url(cls, url):
         return cls.url_extension(url) == 'mp3'
+
+    def set_values(self, video):
+        cmd = """avprobe -v error -show_format -show_streams "{}" | grep duration= | sed 's/^.*=//' | head -n1""".format(self.url)
+        try:
+            duration = int(float(subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)))
+            video.duration = duration
+        except subprocess.CalledProcessError as e:
+            logger.error("CalledProcessError error({}) when running command {}".format(e.returncode, cmd))
+        except:
+            logger.error("Unexpected error({}) when running command {}".format(sys.exc_info()[0], cmd))

--- a/apps/videos/types/vimeo.py
+++ b/apps/videos/types/vimeo.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see 
 # http://www.gnu.org/licenses/agpl-3.0.html.
 
+import requests
 from vidscraper.sites import vimeo
 from vidscraper.errors import Error as VidscraperError
 from base import VideoType, VideoTypeError
@@ -74,6 +75,21 @@ class VimeoVideoType(VideoType):
             except Exception:
                 # in case the Vimeo video is private.
                 pass
+        r = requests.get("https://player.vimeo.com/video/{}/config".format(self.video_id))
+        if r.status_code == requests.codes.ok:
+            try:
+                video_obj.duration = r.json[u"video"]["duration"]
+            except:
+                pass
     
     def _get_vimeo_id(self, video_url):
         return vimeo.VIMEO_REGEX.match(video_url).groupdict().get('video_id') 
+
+    def get_direct_url(self):
+        r = requests.get("https://player.vimeo.com/video/{}/config".format(self.video_id))
+        if r.status_code == requests.codes.ok:
+            try:
+                return r.json[u"request"]["files"]["h264"]["mobile"]["url"]
+            except:
+                return None
+        return None

--- a/apps/videos/types/youtube.py
+++ b/apps/videos/types/youtube.py
@@ -76,10 +76,7 @@ class YoutubeVideoType(VideoType):
         return self._video_info
 
     def set_values(self, video, fetch_subs_async=True):
-        try:
-            video_info = self.get_video_info()
-        except google.APIError:
-            return
+        video_info = self.get_video_info()
         video.title = video_info.title
         video.description = video_info.description
         video.duration = video_info.duration

--- a/deploy/requirements.txt
+++ b/deploy/requirements.txt
@@ -80,3 +80,4 @@ selenium
 xvfbwrapper==0.2.4
 factory_boy==2.4.1
 pafy
+isodate==0.5.4


### PR DESCRIPTION
* Public vimeo videos
* Fixes for long youtube videos, duration when no youtube API key
* Duration of mp4, mp3, flv files
* Make sure API does not override automatically set duration
* Get direct access to vimeo video files