### PR TITLE
Revisions page

### DIFF
--- a/media/js/unisubs.site.js
+++ b/media/js/unisubs.site.js
@@ -651,7 +651,6 @@ var Site = function(Site) {
                 return DIFFING_URL.replace(/<<first_pk>>/, first_pk).replace(/<<second_pk>>/, second_pk);
             }
             function setupRevisions() {
-                $('.version_checkbox:first', '.revisions').attr('checked', 'checked');
                 $('.version_checkbox', '.revisions').change( function() {
                     var $this = $(this);
                     var checked_length = $('.version_checkbox:checked').length;

--- a/templates/videos/diffing.html
+++ b/templates/videos/diffing.html
@@ -81,7 +81,7 @@
           </a>
       </li>
       <li>
-          <a href="{{ language.get_absolute_url }}#revisions">
+          <a href="{{ language.get_absolute_url }}?tab=revisions">
               {% trans 'Revision History' %}
           </a>
       </li>


### PR DESCRIPTION
2 fixes to the revisions / diffing pages:
1. Make the tip version on revisions page unchecked by default to simplify selection of any 2 versions for comparison.
2. Fix Revisions History button on the diffing page.