### PR TITLE
Switching embedder to user relative path for Video API

### DIFF
--- a/media/src/js/embedder/embedder.js
+++ b/media/src/js/embedder/embedder.js
@@ -201,7 +201,7 @@
             initialize: function() {
 
                 var video = this;
-                var apiURL = '//' + _amaraConf.baseURL + '/api/videos/?video_url=';
+                var apiURL = '/api/videos/?video_url=';
                 this.subtitles = new that.Subtitles();
                 // Make a call to the Amara API to get attributes like available languages,
                 // internal ID, description, etc.


### PR DESCRIPTION
This fixes one of the first problems I encountered when testing this project locally. `embedder.js` was calling the API with a URL which discarded the subdomain and port; instead of hitting `http://amara.example.com:8000/api/videos/...`, it was hitting `http://example.com/api/videos`. This call was blocked since this was a cross-origin HTTP request, so pages like `/en/videos/...` would fail to load.

This seems like it was an isolated bug. This change switches it to simply use a relative path for the request, which seems to work quite nicely.