### PR TITLE
Added extra margin to editor hover menu

### DIFF
--- a/media/src/css/subtitle-editor/subtitle-editor.scss
+++ b/media/src/css/subtitle-editor/subtitle-editor.scss
@@ -1263,6 +1263,9 @@ div.workspace-tools {
         div.toolbox-inside:hover ul.toolbox-menu {
           display:block;
         }
+        div.toolbox-inside:hover .helper_margin {
+          display:block;
+        }
         div.toolbox-inside {              
            width: 150px;
            position: relative;
@@ -1277,6 +1280,16 @@ div.workspace-tools {
         position: absolute;
         right: 15px;
         padding: 3px 0px 10px 20px;
+        }
+        div.toolbox-inside > .helper_margin{
+          display:none;
+          position: absolute;
+          text-align: left;
+          top: 0;
+          right: -155px;
+          width: 200px;
+          height: 240px;
+          z-index: 62;
         }
 
 

--- a/templates/editor/working-subtitles.html
+++ b/templates/editor/working-subtitles.html
@@ -7,6 +7,8 @@
     </div>
     <div class="toolbox">
         <div class="toolbox-inside">
+            <!-- The "helper_margin" is invisible and adds an extra 45px of hover-area on the left to keep the "toolbox-menu" open -->
+            <div class="helper_margin"></div>
             <a href="#"><img src="{{ STATIC_URL }}images/subtitle-editor/glyphicons_halflings_135_wrench.png" alt="Tools"></img></a>
             <ul class="toolbox-menu">
                 <li ng-show="copyTimingEnabled()"><a href="#" class="copyover" ng-click="showCopyTimingModal($event)" title="Copy timing and paragraphs from reference language">{% trans "Copy Timing" %}</a></li>


### PR DESCRIPTION
Addresses Issue #1740

https://github.com/pculture/unisubs/issues/1740

An empty, invisible div was added to extend the hover area of the editor hover menu.
It acts as an extra margin of 45px to the left of the menu,
eliminating the gap between the icon and the hover menu,
where it is very easy to fall out of the hover area and lose the menu.

This margin runs the full lenght of the editor hover menu,
but can obviously be shortened to match the lenght of the tool icon
if the current area provides too much hover space.