### PR TITLE
Open adjacent cell after deleting a subtitle

### DIFF
--- a/media/src/js/subtitle-editor/app.js
+++ b/media/src/js/subtitle-editor/app.js
@@ -595,8 +595,28 @@ var angular = angular || null;
 			$scope.currentEdit.storedSubtitle());
             } else if (isDel(evt.keyCode) && isAltPressed(evt)) {
                 // Alt+del, remove current subtitle
-		if($scope.currentEdit.storedSubtitle())
-		    $scope.workingSubtitles.subtitleList.removeSubtitle($scope.currentEdit.storedSubtitle());
+		if($scope.currentEdit.storedSubtitle()){
+                    var subtitleList = $scope.workingSubtitles.subtitleList;
+                    var currentSubtitle = $scope.currentEdit.storedSubtitle();
+                    var nextSubtitle = subtitleList.nextSubtitle(currentSubtitle);
+                    var prevSubtitle = subtitleList.prevSubtitle(currentSubtitle);
+                    var replacement = nextSubtitle || prevSubtitle;
+
+                    subtitleList.removeSubtitle(currentSubtitle);
+
+                    // After removing current subtitle, move cursor and open text-area of adjacent subtitle
+                    if (replacement){
+                        // Tell the root scope that we're no longer editing, now.
+                        if($scope.currentEdit.finish(commitChanges = true, subtitleList = subtitleList)) {
+                            $scope.$root.$emit('work-done');
+                        }
+
+                        $scope.currentEdit.start(replacement);
+                        $scope.$root.$emit('scroll-to-subtitle', replacement);
+                        evt.preventDefault();
+                        evt.stopPropagation();
+                   }
+                }
             } else if (isAltPressed(evt) && ((evt.keyCode === 38) || (evt.keyCode === 40))) {
 		var nextSubtitle;
 		var subtitle = $scope.currentEdit.storedSubtitle();


### PR DESCRIPTION
Addresses Issue #2179

https://github.com/pculture/unisubs/issues/2179

Previously, after deleting a subtitle cell,
either by pressing "alt+backspace" or with the context menu,
the cursor would vanish along with the deleted cell.

With the cursor gone and no adjacent cell open for editing,
it was impossible for a user to repeat a press of "alt+backspace" to delete an additional cell.

With this commit, an adjacet cell (if it exists) will open for editing after a subtitle cell is deleted.
If "alt+backspace" is pressed in succession, adjacent cells will be deleted until no cells remain.

This behavior is not produced when deleting a subtitle cell using the context menu.

Note: I found it difficult to delete multiple cells in a row using "alt+backspace" even with this new functionality.
This is because unless the "alt" key is released rather quickly,
the operating system will pick up on the keypress and remove focus from the browser.