### PR TITLE
Speed up the team videos page

### DIFF
--- a/apps/teams/templatetags/teams_tags.py
+++ b/apps/teams/templatetags/teams_tags.py
@@ -322,7 +322,11 @@ def team_projects(context, team, varname):
     {% endfor %}
 
     """
-    context[varname] = Project.objects.for_team(team)
+    projects = Project.objects.for_team(team).select_related('team')
+    project_video_counts = team.get_project_video_counts()
+    for p in projects:
+        p.set_videos_count_cache(project_video_counts.get(p.id, 0))
+    context[varname] = projects
     return ""
 
 @tag(register, [Variable(), Constant("as"), Name()])

--- a/templates/new-teams/videos.html
+++ b/templates/new-teams/videos.html
@@ -54,7 +54,6 @@
     {% endif %}
     <ul class="thumb-list{% if bulk_mode_enabled %} bulk-mode{% endif %}">
       {% for video in page %}
-      {% with team_video=video.get_team_video %}
       <li>
         <div class="thumb">
           <img src="{{ video.get_wide_thumbnail }}" alt="{{ video.title_display }}">
@@ -74,7 +73,6 @@
         {% else %}
         <div class="four-lines">{{ description }}</div>
         {% endif %}
-        {% endwith %}
       </li>
       {% endwith %}
       {% endfor %}


### PR DESCRIPTION
Don't fetch the teamvideo for each video.  We don't even use the
variable.

Cached counting videos per-project.  Some on-demand teams have dozens of
projects and running a query for each is quite slow.