### PR TITLE
Added some extra permissions checking for notes

### DIFF
--- a/apps/subtitles/views.py
+++ b/apps/subtitles/views.py
@@ -214,6 +214,7 @@ class SubtitleEditorBase(View):
             },
             'staticURL': settings.STATIC_URL,
             'notesHeading': 'Editor Notes',
+            'notesEnabled': True,
             'redirectUrl': self.get_redirect_url(),
             'customCss': self.get_custom_css(),
         }

--- a/apps/subtitles/workflows.py
+++ b/apps/subtitles/workflows.py
@@ -198,7 +198,7 @@ class Workflow(object):
         """
         return "<standard>"
 
-    def get_editor_notes(self, language_code):
+    def get_editor_notes(self, user, language_code):
         """Get notes to display in the editor
 
         Returns:
@@ -264,14 +264,20 @@ class Workflow(object):
 
     def editor_data(self, user, language_code):
         """Get data to pass to the editor for this workflow."""
-        editor_notes = self.get_editor_notes(language_code)
-        return {
+        data = {
             'work_mode': self.get_work_mode(user, language_code).editor_data(),
             'actions': [action.editor_data() for action in
                         self.get_actions(user, language_code)],
-            'notesHeading': editor_notes.heading,
-            'notes': editor_notes.note_editor_data(),
         }
+        editor_notes = self.get_editor_notes(user, language_code)
+        if editor_notes:
+            data.update({
+                'notesHeading': editor_notes.heading,
+                'notes': editor_notes.note_editor_data(),
+            })
+        else:
+            data['notesEnabled'] = False
+        return data
 
     def editor_video_urls(self, language_code):
         """Get video URLs to send to the editor."""
@@ -386,8 +392,8 @@ class VideoWorkflow(object):
         return (self.get_language_workflow(language_code)
                 .action_for_add_subtitles(user, complete))
 
-    def get_editor_notes(self, language_code):
-        return self.get_language_workflow(language_code).get_editor_notes()
+    def get_editor_notes(self, user, language_code):
+        return self.get_language_workflow(language_code).get_editor_notes(user)
 
     def lookup_action(self, user, language_code, action_name):
         return (self.get_language_workflow(language_code)
@@ -465,7 +471,7 @@ class LanguageWorkflow(object):
         else:
             return Unpublish()
 
-    def get_editor_notes(self):
+    def get_editor_notes(self, user):
         """Get notes to display in the editor
 
         Returns:
@@ -515,14 +521,20 @@ class LanguageWorkflow(object):
 
     def editor_data(self, user):
         """Get data to pass to the editor for this workflow."""
-        editor_notes = self.get_editor_notes()
-        return {
+        data = {
             'work_mode': self.get_work_mode(user).editor_data(),
             'actions': [action.editor_data() for action in
                         self.get_actions(user)],
-            'notesHeading': editor_notes.heading,
-            'notes': editor_notes.note_editor_data(),
         }
+        editor_notes = self.get_editor_notes(user)
+        if editor_notes:
+            data.update({
+                'notesHeading': editor_notes.heading,
+                'notes': editor_notes.note_editor_data(),
+            })
+        else:
+            data['notesEnabled'] = False
+        return data
 
     def editor_video_urls(self):
         """Get video URLs to send to the editor."""

--- a/apps/teams/tests/test_notes.py
+++ b/apps/teams/tests/test_notes.py
@@ -37,7 +37,7 @@ class TestTeamNotes(TestCase):
 
     def test_workflow_returns_team_editor_notes(self):
         workflow = workflows.get_workflow(self.video)
-        editor_notes = workflow.get_editor_notes('en')
+        editor_notes = workflow.get_editor_notes(self.user, 'en')
         assert_is_instance(editor_notes, TeamEditorNotes)
 
     def test_post_adds_team_subtitle_note(self):
@@ -57,7 +57,7 @@ class TestTaskTeamNotes(TestCase):
 
     def test_workflow_returns_task_team_editor_notes(self):
         workflow = workflows.get_workflow(self.video)
-        editor_notes = workflow.get_editor_notes('en')
+        editor_notes = workflow.get_editor_notes(self.user, 'en')
         assert_is_instance(editor_notes, TaskTeamEditorNotes)
 
     def check_send_messages(self, mock_send_messages, note, recipients):

--- a/apps/teams/workflows/old/subtitleworkflows.py
+++ b/apps/teams/workflows/old/subtitleworkflows.py
@@ -207,7 +207,7 @@ class TaskTeamSubtitlesWorkflow(TeamSubtitlesWorkflow):
                 return [subtitles.workflows.SaveDraft(),
                         subtitles.workflows.Publish()]
 
-    def get_editor_notes(self, language_code):
+    def get_editor_notes(self, user, language_code):
         return TaskTeamEditorNotes(self.team_video, language_code)
 
     def get_add_language_mode(self, user):

--- a/apps/teams/workflows/subtitleworkflows.py
+++ b/apps/teams/workflows/subtitleworkflows.py
@@ -30,7 +30,7 @@ class TeamSubtitlesWorkflow(subtitles.workflows.DefaultWorkflow):
         self.team_video = team_video
         self.team = team_video.team
 
-    def get_editor_notes(self, language_code):
+    def get_editor_notes(self, user, language_code):
         return TeamEditorNotes(self.team_video.team, self.team_video.video,
                                language_code)
 

--- a/media/src/js/subtitle-editor/notes.js
+++ b/media/src/js/subtitle-editor/notes.js
@@ -25,6 +25,7 @@ var angular = angular || null;
     module.controller('NotesController', ["$sce", "$scope", "$timeout", "EditorData", "SubtitleStorage", function($sce, $scope, $timeout, EditorData, SubtitleStorage) {
         $scope.heading = EditorData.notesHeading;
         $scope.newNoteText = "";
+        $scope.enabled = EditorData.notesEnabled;
 	$scope.$root.$on('set-note-heading', function(evt, heading) {
             $scope.newNoteText = heading + "\n";
 	});

--- a/templates/editor/notes.html
+++ b/templates/editor/notes.html
@@ -1,5 +1,6 @@
 {% load i18n %}
 <div class="notes edit-area" ng-controller="NotesController">
+  <div ng-show="enabled">
     <div class="workspace-tools group toolbar"><h3 class="heading">[[ heading ]]</h3></div>
     <ul class="notes" note-scroller ng-click="onNoteClicked($event)">
         <li ng-repeat="note in notes">
@@ -11,4 +12,5 @@
         <textarea ng-model="newNoteText" new-note-focus="newNoteFocus"></textarea>
         <button ng-click="onPostClicked($event);">Post New Note</button>
     </div>
+  </div>
 </div>


### PR DESCRIPTION
Include the user when calling SubtitleWorkflow.get_editor_notes().
Allow the method to return None to disable notes.

This is needed for the evaluation teams feature.  For that there are
cases where we want to allow users to edit the subtitles, but not see
the notes.