### PR TITLE
Ensured info tray is repositioned after subtitle text & DOM updates

### DIFF
--- a/media/src/js/subtitle-editor/subtitles/directives.js
+++ b/media/src/js/subtitle-editor/subtitles/directives.js
@@ -35,7 +35,7 @@ var USER_IDLE_MINUTES = 15;
             });
         };
     });
-    module.directive('workingSubtitles', ['VideoPlayer', function(VideoPlayer) {
+    module.directive('workingSubtitles', ['VideoPlayer', '$timeout', function(VideoPlayer, $timeout) {
         return function link(scope, elem, attrs) {
             var startHelper = $('div.sync-help.begin', elem);
             var endHelper = $('div.sync-help.end', elem);
@@ -129,7 +129,19 @@ var USER_IDLE_MINUTES = 15;
                 if (currentArrow) {
                     currentArrow.hide(); // Kinda hate this, i think it would be cleaner to give each line its own controller
                 }
-                scope.positionInfoTray();
+                $timeout(function() {
+                    // use timeout to make sure that this happens after the DOM has updated,
+                    // since changes to contents of the info tray may have changed its size.
+                    scope.positionInfoTray();
+                }, 0, false);
+            });
+
+            scope.$watch("currentEdit.draft.markdown", function() {
+                $timeout(function() {
+                    // use timeout to make sure that this happens after the DOM has updated,
+                    // since changes to contents of the info tray may have changed its size.
+                    scope.positionInfoTray();
+                }, 0, false);
             });
 
             scope.$watch("timelineShown", function() {


### PR DESCRIPTION
Fixes #2637.

References for using $timeout to update layout based on DOM updates (since this doesn't seem to be directly documented by angularjs):
- https://github.com/angular/angular.js/issues/734
- http://stackoverflow.com/questions/19183049/how-to-call-a-function-when-angular-is-done-updating-the-layout-because-of-data
- http://stackoverflow.com/questions/16066239/defer-angularjs-watch-execution-after-digest-raising-dom-event
- http://stackoverflow.com/questions/29093229/how-to-call-function-when-angular-watch-cycle-or-digest-cycle-is-completed
- http://tech.endeepak.com/blog/2014/05/03/waiting-for-angularjs-digest-cycle/
