### PR TITLE
Fix permission for case when no subtitle type is specified

### DIFF
--- a/apps/subtitles/permissions.py
+++ b/apps/subtitles/permissions.py
@@ -25,6 +25,8 @@ def user_can_view_private_subtitles(user, video, language_code):
     return workflow.user_can_view_private_subtitles(user, language_code)
 
 def user_can_access_subtitles_format(user, format):
+    if format is None:
+        return True
     if format not in SubtitleFormatList:
         return False
     f = SubtitleFormatList[format]


### PR DESCRIPTION
Currently, one of the test breaks because trying to get or set subtitles with no format specified fails saing permission is denied, while it should default to `dfxp`. This commit resolves this issue.