### PR TITLE
Fix for action name when uploading subtitles from editor

### DIFF
--- a/media/src/js/subtitle-editor/app.js
+++ b/media/src/js/subtitle-editor/app.js
@@ -709,7 +709,7 @@ var angular = angular || null;
                     $scope.duration,
                     $scope.workingSubtitles.description,
                     $scope.workingSubtitles.metadata,
-                    null, "save-draft", sub_format).then(
+                    null, "", sub_format).then(
                         function onSuccess(data, status, xhr) {
 			    location.reload();
 		        },


### PR DESCRIPTION
The issue is that we push subtitles via the API with a "save-draft" action name. But this action is not valid after subtitles are published.

In branch gh-2710, this was fixed by not setting the action name, it should be set automatically.