### PR TITLE
Fix for project filter initial values

### DIFF
--- a/apps/teams/forms.py
+++ b/apps/teams/forms.py
@@ -262,7 +262,7 @@ class ProjectField(AmaraChoiceField):
             self._setup_widget_choices()
 
     def prepare_value(self, value):
-        return value.id if isinstance(value, Project) else value
+        return value.slug if isinstance(value, Project) else value
 
     def clean(self, value):
         if not self.enabled or value in EMPTY_VALUES or not self.team:

--- a/apps/teams/views.py
+++ b/apps/teams/views.py
@@ -54,6 +54,7 @@ from teams.forms import (
     MoveTeamVideoForm, TaskUploadForm, make_billing_report_form,
     TaskCreateSubtitlesForm, TeamMultiVideoCreateSubtitlesForm,
     OldMoveVideosForm, AddVideoToTeamForm, GuidelinesLangMessagesForm,
+    ProjectField,
 )
 from teams.oldforms import DeleteLanguageForm, AddTeamVideoForm
 from teams.models import (
@@ -540,6 +541,7 @@ def detail(request, slug, project_slug=None, languages=None):
         'team': team,
         'member': member,
         'project':project,
+        'project_field_initial': ProjectField().prepare_value(project),
         'project_filter': project_filter,
         'language_filter': language_filter,
         'language_code': language_code,

--- a/templates/teams/videos-list.html
+++ b/templates/teams/videos-list.html
@@ -44,10 +44,10 @@
                 </fieldset>
             </form>
             {% if can_move_videos %}
-                <a href="{% url "teams:move_videos" team.slug %}{% if project %}?project={{ project.pk }}{% endif %}" class="button">{% trans "Move Videos" %}</a>
+                <a href="{% url "teams:move_videos" team.slug %}{% if project %}?project={{ project_field_initial }}{% endif %}" class="button">{% trans "Move Videos" %}</a>
             {% endif %}
             {% if can_add_video %}
-                <a href="{% url "teams:add_video" team.slug %}{% if project %}?project={{ project.pk }}{% endif %}" class="button">{% trans "Add Video" %}</a>
+                <a href="{% url "teams:add_video" team.slug %}{% if project %}?project={{ project_field_initial }}{% endif %}" class="button">{% trans "Add Video" %}</a>
             {% endif %}
             {% if team|can_view_settings_tab:user %}
                 <a class="button" href="{% url "teams:settings_feeds" slug=team.slug %}">


### PR DESCRIPTION
Made it so we call prepare_value() which should do the right thing
regardless of if we use ids, slugs, or whatever for project values.

Fixed prepare_value() so that it works with our hack to use slugs for
now.