### PR TITLE
Prevent exception with old syncedsubtitleversions (#2770)

### DIFF
--- a/apps/externalsites/models.py
+++ b/apps/externalsites/models.py
@@ -633,6 +633,11 @@ class SyncedSubtitleVersion(models.Model):
     def get_account(self):
         return get_account(self.account_type, self.account_id)
 
+    def is_for_account(self, account):
+        AccountModel = _account_type_to_model[self.account_type]
+        return (isinstance(account, AccountModel) and
+                account.id == self.account_id)
+
 class SyncHistoryQuerySet(query.QuerySet):
     def fetch_with_accounts(self):
         """Fetch SyncHistory objects and join them to their related accounst

--- a/apps/videos/oldviews.py
+++ b/apps/videos/oldviews.py
@@ -604,16 +604,18 @@ class LanguagePageContextSyncHistory(LanguagePageContext):
         for video_url in video.get_video_urls():
             if not can_sync_videourl(video_url):
                 continue
-            try:
-                version = (language.syncedsubtitleversion_set.
-                           select_related('version').
-                           get(video_url=video_url)).version
-            except ObjectDoesNotExist:
-                version = None
+            version = None
+            sync_account = get_sync_account(video, video_url)
+            synced_version_qs = (language.syncedsubtitleversion_set
+                                 .select_related('version'))
+            for ssv in synced_version_qs:
+                if ssv.is_for_account(sync_account):
+                    version = ssv.version
+                    break
             synced_versions.append({
                 'video_url': video_url,
                 'version': version,
-                'syncable': get_sync_account(video, video_url),
+                'syncable': sync_account is not None,
             })
         self['synced_versions'] = synced_versions
 


### PR DESCRIPTION
I'm not sure how this happens, but we have instances of an multiple
SyncedSubtitleVersion objects in the database for a single
video_url/language tuple.  It seems that this happens when the account
gets deleted, but we don't delete the related SyncedSubtitleVersion
object.  Maybe this has to do with old code, not sure.

In any case, I made it so we figure out which SyncedSubtitleVersion is
the correct one for the current sync account and we use that one.