### PR TITLE
Gh enterprise 1612

### DIFF
--- a/apps/externalsites/models.py
+++ b/apps/externalsites/models.py
@@ -633,7 +633,6 @@ def get_sync_accounts(video):
     return rv
 
 def get_sync_account(video, video_url):
-    video_url.fix_owner_username()
     AccountModel = _video_type_to_account_model.get(video_url.type)
     if AccountModel is None:
         return None

--- a/apps/externalsites/tasks.py
+++ b/apps/externalsites/tasks.py
@@ -115,7 +115,6 @@ def update_all_subtitles(account_type, account_id):
 
     for video in videos.all():
         for video_url in video.get_video_urls():
-            video_url.fix_owner_username()
             if not account.should_sync_video_url(video, video_url):
                 continue
             language_qs = (video.newsubtitlelanguage_set

--- a/apps/videos/models.py
+++ b/apps/videos/models.py
@@ -732,7 +732,7 @@ class Video(models.Model):
             video = Video.objects.create()
             vt, video_url = video._add_video_url(url, user, True)
             # okay, we can now run the setup
-            video.set_values(vt, user, team)
+            video.set_values(vt, video_url, user, team)
             video.user = user
             if setup_callback:
                 setup_callback(video, video_url)
@@ -751,8 +751,8 @@ class Video(models.Model):
 
         return (video, video_url)
 
-    def set_values(self, video_type, user, team):
-        video_type.set_values(self, user, team)
+    def set_values(self, video_type, video_url, user, team):
+        video_type.set_values(self, user, team, video_url)
         self.title = self.re_unicode.sub(u'\uFFFD', self.title)
         self.description = self.re_unicode.sub(u'\uFFFD', self.description)
 
@@ -794,7 +794,6 @@ class Video(models.Model):
                 'primary': primary,
                 'original': primary,
                 'videoid': vt.video_id if vt.video_id else '',
-                'owner_username': vt.owner_username(),
             })
         if not created:
             raise Video.UrlAlreadyAdded(video_url)
@@ -2149,25 +2148,6 @@ class VideoUrl(models.Model):
 
         signals.video_url_deleted.send(sender=self, user=user)
         self.delete()
-
-    def fix_owner_username(self):
-        """Workaround for us changing how owner_usernames work.
-
-        At some point we changed how owner_usernames works for youtube videos.
-        Rather than trying to change the owner_usernames attribute for all
-        videos at once in a huge migration, we set them to None.  Then before
-        we need to use the username, we call fix_owner_username() and fix it
-        then.
-        """
-        # We should not do that as it calls the API each time
-        return
-        types_to_fix = (
-            VIDEO_TYPE_YOUTUBE,
-        )
-
-        if self.type in types_to_fix and self.owner_username is None:
-            self.owner_username = self.get_video_type().owner_username()
-            self.save()
 
     def get_video_type_class(self):
         try:

--- a/apps/videos/tests/test_video_types.py
+++ b/apps/videos/tests/test_video_types.py
@@ -103,10 +103,6 @@ class YoutubeVideoTypeTest(TestCase):
         self.assertEqual(video.description, '')
         self.assertEqual(video.duration, None)
         self.assertEqual(video.thumbnail, '')
-        # since get_video_info failed, we don't know the channel id of our
-        # video URL.  We should use a dummy value to make it easier to fix the
-        # issue in the future
-        self.assertEqual(vt.owner_username(), None)
 
     def test_matches_video_url(self):
         for item in self.data:

--- a/apps/videos/types/base.py
+++ b/apps/videos/types/base.py
@@ -138,11 +138,8 @@ class VideoType(object):
             'allow_community_edits': True
         }
 
-    def set_values(self, video, user, team):
+    def set_values(self, video, user, team, video_url):
         pass
-
-    def owner_username(self):
-        return None
     
     @classmethod
     def format_url(cls, url):

--- a/apps/videos/types/dailymotion.py
+++ b/apps/videos/types/dailymotion.py
@@ -51,7 +51,7 @@ class DailymotionVideoType(VideoType):
     def matches_video_url(cls, url):
         return bool(cls.get_video_id(url))
 
-    def set_values(self, video_obj, user, team):
+    def set_values(self, video_obj, user, team, video_url):
         metadata = self.get_metadata(self.video_id)
         video_obj.description = metadata.get('description', u'')
         video_obj.title = metadata.get('title', '')

--- a/apps/videos/types/flv.py
+++ b/apps/videos/types/flv.py
@@ -36,7 +36,7 @@ class FLVVideoType(VideoType):
     def matches_video_url(cls, url):
         return cls.url_extension(url) == 'flv'
 
-    def set_values(self, video, user, team):
+    def set_values(self, video, user, team, video_url):
         cmd = """avprobe -v error -show_format -show_streams "{}" | grep duration= | sed 's/^.*=//' | head -n1""".format(self.url)
         try:
             duration = int(float(subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)))

--- a/apps/videos/types/googledrive.py
+++ b/apps/videos/types/googledrive.py
@@ -66,7 +66,7 @@ class GoogleDriveVideoType(VideoType):
                 self.file_id))
             raise
 
-    def set_values(self, video, user, team):
+    def set_values(self, video, user, team, video_url):
         try:
             video_info = self.get_drive_file_info()
         except google.APIError:

--- a/apps/videos/types/htmlfive.py
+++ b/apps/videos/types/htmlfive.py
@@ -83,7 +83,7 @@ class HtmlFiveVideoType(VideoType):
     def get_direct_url(self, prefer_audio=False):
         return self.url
 
-    def set_values(self, video, user, team):
+    def set_values(self, video, user, team, video_url):
         cmd = """avprobe -v error -show_format -show_streams "{}" 2>&1 """.format(self.url)
         try:
             with Popen(cmd, shell=True, stdout=PIPE, preexec_fn=os.setsid) as process:

--- a/apps/videos/types/mp3.py
+++ b/apps/videos/types/mp3.py
@@ -37,7 +37,7 @@ class Mp3VideoType(VideoType):
     def matches_video_url(cls, url):
         return cls.url_extension(url) == 'mp3'
 
-    def set_values(self, video, user, team):
+    def set_values(self, video, user, team, video_url):
         cmd = """avprobe -v error -show_format -show_streams "{}" | grep duration= | sed 's/^.*=//' | head -n1""".format(self.url)
         try:
             duration = int(float(subprocess.check_output(cmd, shell=True, stderr=subprocess.STDOUT)))

--- a/apps/videos/types/ustream.py
+++ b/apps/videos/types/ustream.py
@@ -36,7 +36,7 @@ class UstreamVideoType(VideoType):
     def matches_video_url(cls, url):
         return bool(ustream.USTREAM_REGEX.match(url))
 
-    def set_values(self, video_obj, user, team):
+    def set_values(self, video_obj, user, team, video_url):
         video_obj.title = ustream.get_title(self.url)
         video_obj.description = ustream.get_description(self.url)
         video_obj.thumbnail = ustream.get_thumbnail_url(self.url)

--- a/apps/videos/types/video_google.py
+++ b/apps/videos/types/video_google.py
@@ -32,7 +32,7 @@ class GoogleVideoType(VideoType):
     def matches_video_url(cls, url):
         return bool(google_video.GOOGLE_VIDEO_REGEX.match(url))
 
-    def set_values(self, video_obj, user, team):
+    def set_values(self, video_obj, user, team, video_url):
         video_obj.title = google_video.scrape_title(self.url)
         video_obj.description = google_video.scrape_description(self.url)
         raise Warning('GoogleVideoType does not support thumbnail loading')

--- a/apps/videos/types/vimeo.py
+++ b/apps/videos/types/vimeo.py
@@ -54,7 +54,7 @@ class VimeoVideoType(VideoType):
     def matches_video_url(cls, url):
         return bool(vimeo.VIMEO_REGEX.match(url))
 
-    def set_values(self, video_obj, user, team):
+    def set_values(self, video_obj, user, team, video_url):
         if vimeo.VIMEO_API_KEY and vimeo.VIMEO_API_SECRET:
             try:
                 video_obj.thumbnail = vimeo.get_thumbnail_url(self.url, self.shortmem) or ''

--- a/apps/videos/types/wistia.py
+++ b/apps/videos/types/wistia.py
@@ -55,7 +55,7 @@ class WistiaVideoType(VideoType):
     def matches_video_url(cls, url):
         return bool(wistia.WISTIA_REGEX.match(url))
 
-    def set_values(self, video_obj, user, team):
+    def set_values(self, video_obj, user, team, video_url):
         try:
             video_obj.thumbnail = wistia.get_thumbnail_url(self.url, self.shortmem) or ''
             video_obj.small_thumbnail = wistia.get_small_thumbnail_url(self.url, self.shortmem) or ''

--- a/apps/videos/types/youtube.py
+++ b/apps/videos/types/youtube.py
@@ -19,10 +19,12 @@ import re
 from urlparse import urlparse
 
 from base import VideoType
+from celery.task import task
 from externalsites import google
 import externalsites
 import logging
 logger = logging.getLogger(__name__)
+
 class YoutubeVideoType(VideoType):
 
     _url_patterns = [re.compile(x) for x in [
@@ -42,6 +44,7 @@ class YoutubeVideoType(VideoType):
     CAN_IMPORT_SUBTITLES = True
 
     VIDEOID_MAX_LENGTH = 11
+    MAX_ACCOUNTS_TO_TRY = 5
 
     def __init__(self, url):
         self.url = url
@@ -66,28 +69,47 @@ class YoutubeVideoType(VideoType):
         else:
             return google.get_direct_url_to_video(self.video_id)
 
-    def get_video_info(self, user, team):
+    def get_video_info(self, video, user, team, video_url):
+        incomplete = False
         if not hasattr(self, '_video_info'):
             if team is not None and user is not None:
                 accounts = externalsites.models.YouTubeAccount.objects.get_accounts_for_user_and_team(user, team)
             else:
                 accounts = []
-            self._video_info = google.get_video_info(self.video_id, accounts)
-        return self._video_info
+            try:
+                self._video_info = google.get_video_info(self.video_id, accounts[:YoutubeVideoType.MAX_ACCOUNTS_TO_TRY])
+            except:
+                if len(accounts) > YoutubeVideoType.MAX_ACCOUNTS_TO_TRY:
+                    get_set_values_background.apply_async(args=[self.video_id, accounts[YoutubeVideoType.MAX_ACCOUNTS_TO_TRY:],
+                                                                video.pk, video_url.pk], countdown=2)
+                    incomplete = True
+                    self._video_info = None
+                else:
+                    raise
+        return self._video_info, incomplete
 
-    def set_values(self, video, user, team, video_url):
-        try:
-            video_info = self.get_video_info(user, team)
-        except google.APIError:
-            return
-        video.title = video_info.title
-        video.description = video_info.description
+    @classmethod
+    def complete_set_values(cls, video, video_url, video_info):
+        if not video.title:
+            video.title = video_info.title
+        if not video.description:
+            video.description = video_info.description
         video.duration = video_info.duration
-        video.thumbnail = video_info.thumbnail_url
+        if not video.thumbnail:
+            video.thumbnail = video_info.thumbnail_url
         if video_url.owner_username is None and \
            video_info.channel_id is not None:
             video_url.owner_username = video_info.channel_id
             video_url.save()
+
+    def set_values(self, video, user, team, video_url):
+        try:
+            video_info, incomplete = self.get_video_info(video, user, team, video_url)
+        except google.APIError:
+            return
+        if not incomplete:
+            self.complete_set_values(video, video_url, video_info)
+        return incomplete
 
     @classmethod
     def url_from_id(cls, video_id):
@@ -101,3 +123,21 @@ class YoutubeVideoType(VideoType):
             if bool(video_id):
                 return video_id[:YoutubeVideoType.VIDEOID_MAX_LENGTH]
         raise ValueError("Unknown video id")
+
+@task()
+def get_set_values_background(video_id, accounts, video_pk, video_url_pk):
+    from django.db import models
+    from videos.models import Video, VideoUrl
+    try:
+        video = Video.objects.get(id=video_pk)
+        video_url = VideoUrl.objects.get(id=video_url_pk)
+        video_info = google.get_video_info(video_id, accounts)
+        YoutubeVideoType.complete_set_values(video,
+                                             video_url,
+                                             video_info)
+    except models.ObjectDoesNotExist, e:
+        return
+    except Exception, e:
+        logger.error("No values available for video " + video_id)
+    video.update_search_index()
+    video.save()

--- a/apps/videos/types/youtube.py
+++ b/apps/videos/types/youtube.py
@@ -21,7 +21,8 @@ from urlparse import urlparse
 from base import VideoType
 from externalsites import google
 import externalsites
-
+import logging
+logger = logging.getLogger(__name__)
 class YoutubeVideoType(VideoType):
 
     _url_patterns = [re.compile(x) for x in [
@@ -74,7 +75,7 @@ class YoutubeVideoType(VideoType):
             self._video_info = google.get_video_info(self.video_id, accounts)
         return self._video_info
 
-    def set_values(self, video, user, team):
+    def set_values(self, video, user, team, video_url):
         try:
             video_info = self.get_video_info(user, team)
         except google.APIError:
@@ -83,12 +84,10 @@ class YoutubeVideoType(VideoType):
         video.description = video_info.description
         video.duration = video_info.duration
         video.thumbnail = video_info.thumbnail_url
-
-    def owner_username(self):
-        try:
-            return self.get_video_info(None, None).channel_id
-        except google.APIError:
-            return None
+        if video_url.owner_username is None and \
+           video_info.channel_id is not None:
+            video_url.owner_username = video_info.channel_id
+            video_url.save()
 
     @classmethod
     def url_from_id(cls, video_id):


### PR DESCRIPTION
This implements what is said in the ticket (only synchronously check for up to 5 linked accounts for metadata in yotube video), but also cleans up the way we add owner_username, to limit API calls and also use authenticated API calls to get the value for private youtube videos.