### PR TITLE
use old file inputs for settings page

### DIFF
--- a/apps/teams/forms.py
+++ b/apps/teams/forms.py
@@ -840,12 +840,12 @@ class SettingsForm(forms.ModelForm):
     logo = forms.ImageField(
         validators=[MaxFileSizeValidator(settings.AVATAR_MAX_SIZE)],
         help_text=_('Max 940 x 235'),
-        widget=AmaraFileInput,
+        widget=forms.FileInput,
         required=False)
     square_logo = forms.ImageField(
         validators=[MaxFileSizeValidator(settings.AVATAR_MAX_SIZE)],
         help_text=_('Recommended size: 100 x 100'),
-        widget=AmaraFileInput,
+        widget=forms.FileInput,
         required=False)
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
teams setting page doesn't include the future ui assets which the new file field widgets use, so for now using the old field widgets on this page