### PR TITLE
Various fixes and improvements for Video URLs

### DIFF
--- a/apps/api/views/videos.py
+++ b/apps/api/views/videos.py
@@ -248,7 +248,7 @@ from teams import permissions as team_perms
 from teams.models import Team, TeamVideo, Project
 from subtitles.models import SubtitleLanguage
 from videos import metadata
-from videos.models import Video
+from videos.models import Video, URL_MAX_LENGTH
 from videos.types import video_type_registrar, VideoTypeError
 import videos.tasks
 
@@ -361,7 +361,9 @@ class VideoSerializer(serializers.Serializer):
     # Note we could try to use ModelSerializer, but we are so far from the
     # default implementation that it makes more sense to not inherit.
     id = serializers.CharField(source='video_id', read_only=True)
-    video_url = serializers.URLField(write_only=True, required=True)
+    video_url = serializers.URLField(write_only=True,
+                                     required=True,
+                                     max_length=URL_MAX_LENGTH)
     video_type = serializers.SerializerMethodField()
     primary_audio_language_code = LanguageCodeField(required=False,
                                                     allow_blank=True)
@@ -397,10 +399,10 @@ class VideoSerializer(serializers.Serializer):
     default_error_messages = {
         'project-without-team': "Can't specify project without team",
         'unknown-project': 'Unknown project: {project}',
-        'video-exists': 'Video already added for {url}',
-        'video-policy-error': ('Video for {url} not moved because it would '
+        'video-exists': u'Video already added for {url}',
+        'video-policy-error': (u'Video for {url} not moved because it would '
                                'conflict with the video policy for {team}'),
-        'invalid-url': 'Invalid URL: {url}',
+        'invalid-url': u'Invalid URL: {url}',
     }
 
     class Meta:
@@ -701,7 +703,7 @@ class VideoViewSet(mixins.CreateModelMixin,
 
 class VideoURLSerializer(serializers.Serializer):
     created = TimezoneAwareDateTimeField(read_only=True)
-    url = serializers.CharField()
+    url = serializers.URLField(max_length=URL_MAX_LENGTH)
     primary = serializers.BooleanField(required=False)
     original = serializers.BooleanField(required=False)
     id = serializers.IntegerField(read_only=True)

--- a/apps/teams/forms.py
+++ b/apps/teams/forms.py
@@ -500,7 +500,8 @@ class AddMultipleTeamVideoForm(forms.Form):
         video_urls = self.cleaned_data['video_urls'].split("\n")
         # See if any error happen when we create our videos
         for video_url in video_urls:
-            if len(video_url.strip()) == 0:
+            video_url = video_url.strip()
+            if len(video_url) == 0:
                 continue
             try:
                 Video.add(video_url, self.user, self.setup_video, self.team)

--- a/apps/videos/management/commands/encode_urls.py
+++ b/apps/videos/management/commands/encode_urls.py
@@ -1,0 +1,45 @@
+# Amara, universalsubtitles.org
+#
+# Copyright (C) 2017 Participatory Culture Foundation
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see
+# http://www.gnu.org/licenses/agpl-3.0.html.
+
+from django.core.management.base import BaseCommand
+
+from utils.url_escape import url_escape
+from videos.models import VideoUrl
+from videos.types.htmlfive import HtmlFiveVideoType
+from videos.types.flv import FLVVideoType
+from videos.types.mp3 import Mp3VideoType
+
+class Command(BaseCommand):
+    help = "Percent-encode Video URLs if needed"
+
+    def handle(self, **options):
+        count_processed = 0
+        count_changed = 0
+        direct_file_types = [HtmlFiveVideoType.abbreviation,
+                             FLVVideoType.abbreviation,
+                             Mp3VideoType.abbreviation]
+        for video_url in VideoUrl.objects.filter(type__in=direct_file_types):
+            escaped_url = url_escape(video_url.url)
+            if escaped_url != video_url.url:
+                video_url.url = escaped_url
+                video_url.save()
+                count_changed += 1
+            count_processed += 1
+            if count_processed % 1000 == 0:
+                print "processed {} video URLs, converted {}".format(count_processed, count_changed)
+        print "processed {} video URLs, converted {}".format(count_processed, count_changed)

--- a/apps/videos/models.py
+++ b/apps/videos/models.py
@@ -67,6 +67,8 @@ from teams.moderation_const import MODERATION_STATUSES, UNMODERATED
 
 logger = logging.getLogger("videos-models")
 
+URL_MAX_LENGTH = 2048
+
 NO_SUBTITLES, SUBTITLES_FINISHED = range(2)
 VIDEO_TYPE_HTML5 = 'H'
 VIDEO_TYPE_YOUTUBE = 'Y'
@@ -2198,7 +2200,7 @@ class VideoUrl(models.Model):
     # type should be 2 chars long with the first char being unique for the
     # app.
     type = models.CharField(max_length=2)
-    url = models.URLField(max_length=2048)
+    url = models.URLField(max_length=URL_MAX_LENGTH)
     url_hash = models.CharField(max_length=32)
     videoid = models.CharField(max_length=50, blank=True)
     primary = models.BooleanField(default=False)

--- a/apps/videos/tests/test_models.py
+++ b/apps/videos/tests/test_models.py
@@ -21,6 +21,7 @@ import functools
 
 from django.db import IntegrityError
 from django.test import TestCase, TransactionTestCase
+from django.utils.encoding import iri_to_uri
 from nose.tools import *
 import babelsubs
 import mock
@@ -62,7 +63,7 @@ class TestVideoUrl(TestCase):
         unicode_url = u"http://\u2014.com"
         self.primary_url.url = unicode_url
         self.primary_url.save()
-        self.assertEqual(unicode_url, self.primary_url.url)
+        self.assertEqual(iri_to_uri(unicode_url), self.primary_url.url)
 
     def test_unique_error_message(self):
         self.assertEqual(self.url.unique_error_message(None, ['url']),

--- a/apps/videos/types/base.py
+++ b/apps/videos/types/base.py
@@ -17,13 +17,16 @@
 # http://www.gnu.org/licenses/agpl-3.0.html.
 
 from urlparse import urlparse
-
-from django.core.exceptions import ValidationError
 import subprocess, sys, uuid, os
 import requests
-from django.conf import settings
 import logging
-logger = logging.getLogger("Base video type")
+
+from django.core.exceptions import ValidationError
+from django.conf import settings
+
+from utils.url_escape import url_escape
+
+logger = logging.getLogger(__name__)
 
 class VideoType(object):
 
@@ -33,7 +36,7 @@ class VideoType(object):
     CAN_IMPORT_SUBTITLES = False
 
     def __init__(self, url):
-        self.url = url
+        self.url = url_escape(url)
 
     @property
     def video_id(self):

--- a/apps/videos/types/flv.py
+++ b/apps/videos/types/flv.py
@@ -26,9 +26,6 @@ class FLVVideoType(VideoType):
     abbreviation = 'L'
     name = 'FLV'
 
-    def __init__(self, url):
-        self.url = url
-
     def get_direct_url(self, prefer_audio=False):
         return self.url
 

--- a/apps/videos/types/htmlfive.py
+++ b/apps/videos/types/htmlfive.py
@@ -73,9 +73,6 @@ class HtmlFiveVideoType(VideoType):
 
     valid_extensions = set(['ogv', 'ogg', 'mp4', 'm4v', 'webm'])
 
-    def __init__(self, url):
-        self.url = url
-
     @classmethod
     def matches_video_url(cls, url):
         return cls.url_extension(url) in cls.valid_extensions

--- a/apps/videos/types/mp3.py
+++ b/apps/videos/types/mp3.py
@@ -27,9 +27,6 @@ class Mp3VideoType(VideoType):
     abbreviation = 'M'
     name = 'MP3'
 
-    def __init__(self, url):
-        self.url = url
-
     def get_direct_url(self, prefer_audio=False):
         return self.url
 

--- a/utils/url_escape.py
+++ b/utils/url_escape.py
@@ -1,0 +1,6 @@
+from django.utils.encoding import iri_to_uri
+
+def url_escape(url):
+    if isinstance(url, basestring):
+        return iri_to_uri(url)
+    return url


### PR DESCRIPTION
* We now use percent-encoded URLs, generated from IRIs when URLs are submitted
* A management command converts existing IRIs to percent-encoded URLs
* Fixed an issue when adding multiple URLs
* Fixed an issue with errors messages in API when a URL with unicode characters had an issue
* Properly retrieves video duration of all videos (was failing for IRIs with unicode characters
* Fixed an issue with the form when adding multiple URLs
* Made max length of video urls consistent across API and UI